### PR TITLE
Update MongoDB Connection Variable

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,2 +1,2 @@
-MONGO_URI=mongodb+srv://admin:Y3Mja65iaNZlh2w5@cluster0.xozpyua.mongodb.net/
+MONGO_CONNECTION=mongodb+srv://admin:Y3Mja65iaNZlh2w5@cluster0.xozpyua.mongodb.net/
 SESSION_SECRET=got_shit_done_secret

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const plm = require('passport-local-mongoose');
 
 // Setup MongoDB connection
-const connectionURI = process.env.MONGO_URI || "mongodb://127.0.0.1:27017/pinterest-clone";
+const connectionURI = process.env.MONGO_CONNECTION || "mongodb://127.0.0.1:27017/pinterest-clone";
 
 mongoose.connect(connectionURI).then(() => {
   console.log("Connected to MongoDB");


### PR DESCRIPTION
Updated the backend to use `MONGO_CONNECTION` environment variable for the MongoDB Atlas connection instead of `MONGO_URI`. This ensures the requested connection string setup enables the expected authentication flow.

---
*PR created automatically by Jules for task [4537482981646313127](https://jules.google.com/task/4537482981646313127) started by @jxlee007*